### PR TITLE
엔티티 equals() 수정

### DIFF
--- a/src/main/java/com/project/projectboard/domain/Article.java
+++ b/src/main/java/com/project/projectboard/domain/Article.java
@@ -56,8 +56,8 @@ public class Article extends AuditingFields{
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        if (!(o instanceof Article that)) return false;
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/project/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/project/projectboard/domain/ArticleComment.java
@@ -46,8 +46,7 @@ public class ArticleComment extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
-    }
+        return id != null && id.equals(that.getId());    }
 
     @Override
     public int hashCode() {

--- a/src/main/java/com/project/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/project/projectboard/domain/UserAccount.java
@@ -45,8 +45,8 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        if (!(o instanceof UserAccount that)) return false;
+        return userId != null && userId.equals(that.getUserId());
     }
 
     @Override


### PR DESCRIPTION
테스트 도중 밝혀진 엔티티 `equals()` 구현 코드의 문제를 해결

This closes #47 