### PR TITLE
헤로쿠에 배포하기 - DB 변경 (ClearDB -> JawsDB)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -33,7 +33,7 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always
 


### PR DESCRIPTION
조사해본 결과, cleardb 의 기본 mysql 버전이 너무 낮기 때문에 jawsdb 를 찾아냄 
(`article_comment_content` 인덱스 사이즈가 너무 큼)
기본 mysql 버전 이를 이용해 환경변수를 다시 작업함

This fixes #51 