### PR TITLE
[고도화] 엔티티 코드 리팩토링 - equals(), hashcode()에서 필드 접근을 getter로 바꾸기

### DIFF
--- a/src/main/java/com/project/projectboard/domain/Article.java
+++ b/src/main/java/com/project/projectboard/domain/Article.java
@@ -57,12 +57,12 @@ public class Article extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Article that)) return false;
-        return id != null && id.equals(that.getId());
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }
 

--- a/src/main/java/com/project/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/project/projectboard/domain/ArticleComment.java
@@ -46,10 +46,10 @@ public class ArticleComment extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.getId());    }
-
+        return this.getId() != null && this.getId().equals(that.getId());
+    }
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+            return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/project/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/project/projectboard/domain/UserAccount.java
@@ -46,12 +46,12 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount that)) return false;
-        return userId != null && userId.equals(that.getUserId());
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 
 


### PR DESCRIPTION
이 pr은 엔티티의 `equals()`, `hashcode()`가 값 비교를 하기 위해 필드 직접 접근하는 것을 getter 접근으로 바꾼다.
프록시 객체를 사용하는 하이버네이트의 지연 로딩을 고려하여, 값 비교를 제대로 수행하지 못하는 일이 없도록 한다.

This closes #76 